### PR TITLE
The race condition between providers is fixed

### DIFF
--- a/src/couch_epi_data.erl
+++ b/src/couch_epi_data.erl
@@ -53,6 +53,7 @@ childspec(Id, App, EpiKey, Module) ->
     }.
 
 start_link(SubscriberApp, {epi_key, Key}, Module, Options) ->
+    maybe_start_keeper(Key),
     gen_server:start_link(?MODULE, [SubscriberApp, Module, Key, Options], []).
 
 reload(Server) ->
@@ -149,3 +150,7 @@ current(Handle, Subscriber) ->
     catch error:undef ->
         []
     end.
+
+maybe_start_keeper(Key) ->
+    Handle = couch_epi_data_gen:get_handle(Key),
+    couch_epi_module_keeper:maybe_start_keeper(couch_epi_data_gen, Handle).

--- a/src/couch_epi_data_gen.erl
+++ b/src/couch_epi_data_gen.erl
@@ -23,12 +23,14 @@
 -export([by_source/1, by_source/2]).
 -export([keys/1, subscribers/1]).
 
+-export([save/3]).
+
 set(Handle, Source, Data) ->
     case is_updated(Handle, Source, Data) of
         false ->
             ok;
         true ->
-            save(Handle, Source, Data)
+            couch_epi_module_keeper:save(Handle, Source, Data)
     end.
 
 get(Handle) ->

--- a/src/couch_epi_functions.erl
+++ b/src/couch_epi_functions.erl
@@ -53,6 +53,7 @@ childspec(Id, App, Key, Module) ->
     }.
 
 start_link(ProviderApp, {epi_key, ServiceId}, {modules, Modules}, Options) ->
+    maybe_start_keeper(ServiceId),
     gen_server:start_link(
         ?MODULE, [ProviderApp, ServiceId, Modules, Options], []).
 
@@ -148,3 +149,7 @@ safe_remove(#state{} = State) ->
     catch Class:Reason ->
         {{Class, Reason}, State}
     end.
+
+maybe_start_keeper(ServiceId) ->
+    Handle = couch_epi_functions_gen:get_handle(ServiceId),
+    couch_epi_module_keeper:maybe_start_keeper(couch_epi_functions_gen, Handle).

--- a/src/couch_epi_functions_gen.erl
+++ b/src/couch_epi_functions_gen.erl
@@ -14,6 +14,8 @@
 
 -export([add/3, remove/3, get_handle/1, hash/1, apply/4, apply/5]).
 
+-export([save/3]).
+
 -ifdef(TEST).
 
 -export([foo/2, bar/0]).
@@ -32,7 +34,7 @@ add(Handle, Source, Modules) ->
         false ->
             ok;
         true ->
-            save(Handle, Source, Modules)
+            couch_epi_module_keeper:save(Handle, Source, Modules)
     end.
 
 remove(Handle, Source, Modules) ->

--- a/src/couch_epi_module_keeper.erl
+++ b/src/couch_epi_module_keeper.erl
@@ -1,0 +1,78 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_epi_module_keeper).
+
+-behaviour(gen_server).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([maybe_start_keeper/2]).
+-export([start_link/2, save/3]).
+-export([stop/1]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {codegen, module}).
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+maybe_start_keeper(Codegen, Module) ->
+    catch couch_epi_keeper_sup:start_child(Codegen, Module).
+
+start_link(Codegen, Module) ->
+    gen_server:start_link({local, Module}, ?MODULE, [Codegen, Module], []).
+
+stop(Server) ->
+    catch gen_server:call(Server, stop).
+
+save(Server, Source, Config) ->
+    gen_server:call(Server, {save, Source, Config}).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+
+init([Codegen, Module]) ->
+    {ok, #state{codegen = Codegen, module = Module}}.
+
+handle_call({save, Source, Config}, _From, State) ->
+    #state{codegen = Codegen, module = Module} = State,
+    Reply = Codegen:save(Module, Source, Config),
+    {reply, Reply, State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------


### PR DESCRIPTION
In previous design there is a race condition between the time we read the
current definitions in the generated module and the time we compile new
version of it. This race led to overwriting of data of already
configured providers.

This commit fixes the issue by introducing couch_epi_module_keeper
process. This process is named by generated module name and it is
essentially a requests serializer.
