### PR TITLE
Restore R14 compatibility

### DIFF
--- a/src/couch_epi_data_source.erl
+++ b/src/couch_epi_data_source.erl
@@ -178,7 +178,7 @@ read({file, FilePath}) ->
 
 hash_of_file(FilePath) ->
     {ok, Data} = file:read_file(FilePath),
-    crypto:hash(md5, Data).
+    couch_epi_util:md5(Data).
 
 current(Handle, Subscriber) ->
     try

--- a/src/couch_epi_util.erl
+++ b/src/couch_epi_util.erl
@@ -12,7 +12,7 @@
 
 -module(couch_epi_util).
 
--export([module_version/1, hash/1]).
+-export([module_version/1, hash/1, md5/1]).
 
 module_version(Module) ->
     Attributes = Module:module_info(attributes),
@@ -20,5 +20,13 @@ module_version(Module) ->
     VSNs.
 
 hash(Term) ->
-    <<SigInt:128/integer>> = crypto:hash(md5, term_to_binary(Term)),
+    <<SigInt:128/integer>> = md5(term_to_binary(Term)),
     io_lib:format("\"~.36B\"",[SigInt]).
+
+md5(Data) ->
+    case erlang:function_exported(crypto, hash, 2) of
+	true ->
+	    crypto:hash(md5, Data);
+	false ->
+	    crypto:md5(Data)
+    end.


### PR DESCRIPTION
CouchDB 2.0 will be compatible with R14. Support for R14 to be dropped
after.

closes COUCHDB-2755
