### PR TITLE
Ensure calling order of plugins during dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Notes:
   - if there are multiple plugins providing same service they will be called in the order
     they listed in application:get_env(couch_epi, plugins)
   - if the same plugin provides multiple implementations of the same service
-    the order is undefined (fixable)
+    the order is as defined in providers callback
 
 # couch_epi_plugin behaviour
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ There are multiple ways of doing the apply which is controlled by Opts
 Notes:
 
   - `concurrent` is incompatible with `pipe`
+  - if there are multiple plugins providing same service they will be called in the order
+    they listed in application:get_env(couch_epi, plugins)
+  - if the same plugin provides multiple implementations of the same service
+    the order is undefined (fixable)
 
 # couch_epi_plugin behaviour
 

--- a/src/couch_epi_functions.erl
+++ b/src/couch_epi_functions.erl
@@ -43,6 +43,7 @@ definitions(Modules) ->
     [{M, M:module_info(exports) -- Blacklist} || M <- Modules].
 
 group(KV) ->
-    dict:to_list(lists:foldr(fun({K,V}, D) ->
+    Dict = lists:foldr(fun({K,V}, D) ->
         dict:append_list(K, V, D)
-    end, dict:new(), KV)).
+    end, dict:new(), KV),
+    [{K, lists:reverse(V)} || {K, V} <- dict:to_list(Dict)].

--- a/src/couch_epi_plugin.erl
+++ b/src/couch_epi_plugin.erl
@@ -68,7 +68,7 @@ definitions(Kind, Key) ->
     Filtered = filter_by_key(Definitions, Kind, Key),
     case group_specs(Filtered) of
         [] -> [];
-        [{_, Defs}] -> Defs
+        [{_, Defs}] -> lists:reverse(Defs)
     end.
 
 notify(Key, OldData, NewData, Specs) ->


### PR DESCRIPTION
If there are multiple plugins providing same service they will be called
in the order they listed in application:get_env(couch_epi, plugins).
