### PR TITLE
Add couch_epi:decide/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ Notes:
 
   - `concurrent` is incompatible with `pipe`
 
+## decide functionality
+
+There are cases when we want to call configured providers until any of them
+would make a decission. We also would want to be able to find out if any
+decision has been made so we could call default handler. In order to be able
+to do so there is couch_epi:decide/5. Every service which uses this feature
+would get either:
+
+  - no_decision
+  - {decided, Decision :: term()}
+
+The provider module should return one of the above results. The current logic is
+to call all configured providers in order of their definition until we get
+`{decided, term()}`. If none of the providers would return this term we would
+return `no_decision`.
+
 # couch_epi_plugin behaviour
 
 The module implementing behaviour need to export following functions:

--- a/src/couch_epi.erl
+++ b/src/couch_epi.erl
@@ -22,7 +22,7 @@
     keys/1, subscribers/1]).
 
 %% apply
--export([apply/5]).
+-export([apply/5, decide/5]).
 -export([any/5, all/5]).
 
 -export([is_configured/3]).
@@ -168,3 +168,10 @@ is_configured(Handle, Function, Arity) when Handle /= undefined ->
 
 register_service(Plugin, Children) ->
     couch_epi_sup:plugin_childspecs(Plugin, Children).
+
+-spec decide(Handle :: handle(), ServiceId :: atom(), Function :: atom(),
+    Args :: [term()], Opts :: apply_opts()) ->
+        no_decision | {decided, term()}.
+
+decide(Handle, ServiceId, Function, Args, Opts) when Handle /= undefined ->
+    couch_epi_functions_gen:decide(Handle, ServiceId, Function, Args, Opts).


### PR DESCRIPTION
There are cases when we want to call configured providers until any of
them would make a decision. We also would want to be able to find out
if any decision has been made so we could call default handler.
